### PR TITLE
Fix problem with plugin-manager

### DIFF
--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -137,6 +137,13 @@ class PluginManager:
         await self.load_plugins()
         logger.debug("Plugins reloaded")
 
+    def get_payloads(self) -> List[str]:
+        payloads = []
+        for plugin in self.plugins.values():
+            if hasattr(plugin, 'payloads'):
+                payloads.extend(plugin.payloads)
+        return payloads
+
 class Plugin:
     def __init__(self, options):
         logger.debug(f"Initializing Plugin with options: {options}")


### PR DESCRIPTION
### **User description**
Fixes #4

Add `get_payloads` method to `PluginManager` class in `plugin_manager.py`.

* Add a method `get_payloads` to the `PluginManager` class that returns a list of payloads.
* Ensure the method `get_payloads` is accessible from the `Agent` class in `agent_system.py`.


___

### **Description**
- Introduced `get_payloads` method in the `PluginManager` class to retrieve a list of payloads from all loaded plugins.
- This enhancement improves the functionality of the `PluginManager` by allowing easier access to plugin payloads.
- The method is designed to be compatible with the existing plugin architecture.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plugin_manager.py</strong><dd><code>Introduce get_payloads Method in PluginManager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

plugin_manager.py
<li>Added <code>get_payloads</code> method to <code>PluginManager</code> class.<br> <li> The <code>get_payloads</code> method aggregates payloads from all loaded plugins.<br> <li> Ensured compatibility with existing plugin structure.<br>


</details>


  </td>
  <td><a href="https://github.com/Likhithsai2580/AI-Bug-Bounty/pull/5/files#diff-28bc375e4201ee2bf754c5e2fcdb8a9db0a36b77815a2797486ffb2433f5b181">+165/-158</a></td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

